### PR TITLE
Update cloudStorageStudio.json

### DIFF
--- a/data/tools/cloudStorageStudio.json
+++ b/data/tools/cloudStorageStudio.json
@@ -1,6 +1,6 @@
 {
   "name": "CloudBerry Explorer",
-  "link": "http://www.cerebrata.com/products/cloud-storage-studio/introduction",
+  "link": "http://www.cloudberrylab.com/",
   "platform": "Windows",
   "blockBlobs": "Y",
   "pageBlobs": "Y",


### PR DESCRIPTION
Fix link. Link to homepage provided since CloudBerry Lab advertises multiple versions targetting different cloud storage providers.
